### PR TITLE
The command name doesn't have to include "cli"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "email": "o.gata.ken@gmail.com",
     "url": "sane.jp"
   },
-  "bin": "cli.js",
+  "bin": {
+    "chrome-web-store-item-property": "cli.js",
+    "chrome-web-store-item-property-cli": "cli.js"
+  },
   "dependencies": {
     "chrome-web-store-item-property": "^1.1.0",
     "meow": "^3.3.0"


### PR DESCRIPTION
Like this other package: pachttps://github.com/sindresorhus/clear-cli/blob/master/package.json

I added a `cli`-less command name while leaving the old for backwards-compatibility.